### PR TITLE
fix: Set correct color depth in vnc-server

### DIFF
--- a/main.c
+++ b/main.c
@@ -173,6 +173,12 @@ int main(int argc, char** argv) {
 		goto fail_client;
 	}
 
+	// We need to set bitsPerPixel and depth to the correct values,
+	// otherwise some VNC clients (like gstreamer) won't work
+	vnc_server->bitsPerPixel = 32;
+	vnc_server->depth = 24;
+	vnc_server->serverFormat.depth = 24;
+
 	vnc_server->autoPort = FALSE;
 	vnc_server->port = vnc_server->ipv6port = listen_port;
 	vnc_server->desktopName = "vncmux";


### PR DESCRIPTION
We tried using gstreamer (https://gstreamer.freedesktop.org/) to read from vncmux. Reading directly from shoreline directly worked, from vncmux failed. Some debugging showed that we need to set to color depth to 24 - otherwise gstreamer would try to use 32.
Acutal lines copied from https://github.com/TobleMiner/shoreline/blob/05a2bbfb4559090727c51673e1fb47d20eac5672/vnc.c#L68-L71